### PR TITLE
Update to handle Chrome's password csv format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # csv-toicloudkeychain
-AppleScript that will read a CSV file containing URL, username and password data and import this to iCloud KeyChain via Safari.
+AppleScript that will read a CSV file containing (name, URL, username, password) data and import this to iCloud KeyChain via Safari.
 
 
 ![alt tag](demo.gif)
 
 ## CSV Layout
 Create a CSV without headers with data in the below order.
->url,username,password
+>name,url,username,password
 
 For example, import an entry for the user doggo at woof.org.
->woof.org,doggo,secretbonepass
+>woof,woof.org,doggo,secretbonepass
 
 ## Accessibility Permissions
 Script editor must be given permission under System Preferences - Security & Privacy - Accessibility to run. Ensure you remove this after you have finished running the script.

--- a/csv-toicloudkeychain.applescript
+++ b/csv-toicloudkeychain.applescript
@@ -28,9 +28,10 @@ set vals to {}
 set AppleScript's text item delimiters to ","
 repeat with i from 1 to length of recs
 	set end of vals to text items of (item i of recs)
-	set kcURL to text item 1 of (item i of recs)
-	set kcUsername to text item 2 of (item i of recs)
-	set kcPassword to text item 3 of (item i of recs)
+    -- ignore item 1 "name"
+	set kcURL to text item 2 of (item i of recs)
+	set kcUsername to text item 3 of (item i of recs)
+	set kcPassword to text item 4 of (item i of recs)
 	
 	-- write kcURL, kcUsername and kcPassword into text fields of safari passwords
 	tell application "System Events"
@@ -40,7 +41,7 @@ repeat with i from 1 to length of recs
 				
 				click button "Add" of group 1 of group 1 of it
 				-- write fields
-				tell last row of table 1 of scroll area of group 1 of group 1 of it
+				tell sheet 1 of it
 					set value of text field 1 of it to kcURL
 					keystroke tab
 					set value of text field 2 of it to kcUsername

--- a/csv-toicloudkeychain.applescript
+++ b/csv-toicloudkeychain.applescript
@@ -24,11 +24,11 @@ tell application "System Events"
 end tell
 
 -- getting values for each record
-set vals to {}
 set AppleScript's text item delimiters to ","
 repeat with i from 1 to length of recs
-	set end of vals to text items of (item i of recs)
-    -- ignore item 1 "name"
+	-- if it ends with a blank line
+	if (item i of recs) is "" then exit repeat
+	-- ignore item 1 "name"
 	set kcURL to text item 2 of (item i of recs)
 	set kcUsername to text item 3 of (item i of recs)
 	set kcPassword to text item 4 of (item i of recs)
@@ -43,10 +43,14 @@ repeat with i from 1 to length of recs
 				-- write fields
 				tell sheet 1 of it
 					set value of text field 1 of it to kcURL
-					keystroke tab
 					set value of text field 2 of it to kcUsername
-					keystroke tab
 					set value of text field 3 of it to kcPassword
+					-- press cursor right, moving to the end of the text field
+					key code 124
+					-- type a "z" to modify the password
+					key code 6
+					-- delete the z, so the add button is clickable
+					key code 51
 					keystroke return
 				end tell
 				

--- a/some_doggos.csv
+++ b/some_doggos.csv
@@ -1,5 +1,5 @@
-Akita.com,coldnose,secretwag
-AlaskanHusky.com,coldnose,secretwag
-AlaskanKleeKai.com,coldnose,secretwag
-AlaskanMalamute.com,coldnose,secretwag
-AmericanAkita.com,coldnose,secretwag
+akita,Akita.com,coldnose,secretwag
+alaskan husky,AlaskanHusky.com,coldnose,secretwag
+kleekai,AlaskanKleeKai.com,coldnose,secretwag
+malamute,AlaskanMalamute.com,coldnose,secretwag
+American Akita,AmericanAkita.com,coldnose,secretwag


### PR DESCRIPTION
updates the documentation and functionality to handle the csv format of the current version of chrome (name,url,username,password) and clean up/ fix some things to work on mac 10.14. I also dropped some unused/ useless commands (e.g. vals)